### PR TITLE
Add sliderContent accessibility identifier and update tests

### DIFF
--- a/Sources/Core/AccessibilityIdentifier/SliderAccessibilityIdentifier.swift
+++ b/Sources/Core/AccessibilityIdentifier/SliderAccessibilityIdentifier.swift
@@ -19,4 +19,7 @@ public enum SliderAccessibilityIdentifier {
     @available(*, deprecated, message: "Not used anymore by SparkSlider or SparkUISlider")
     /// The slider accessibility identifier.
     public static let slider = "spark-slider"
+
+    /// The native slider inside the spark slider accessibility identifier.
+    public static let sliderContent = "spark-slider-content"
 }

--- a/Sources/Core/View/SwiftUI/SparkSlider.swift
+++ b/Sources/Core/View/SwiftUI/SparkSlider.swift
@@ -383,6 +383,7 @@ public struct SparkSlider<TitleLabel, ValueLabel, MinValueLabel, MaxValueLabel, 
             }
         }
         .tint(self.viewModel.colors.tintColorToken)
+        .accessibilityIdentifier(SliderAccessibilityIdentifier.sliderContent)
     }
 
     private func valueStyledLabel() -> some View {

--- a/Sources/Core/View/UIKit/SparkUISlider.swift
+++ b/Sources/Core/View/UIKit/SparkUISlider.swift
@@ -130,7 +130,11 @@ public final class SparkUISlider: UIControl {
         return label
     }()
 
-    private let slider = SteppedSlider()
+    private let slider: SteppedSlider = {
+        let slider = SteppedSlider()
+        slider.accessibilityIdentifier = SliderAccessibilityIdentifier.sliderContent
+        return slider
+    }()
 
     private lazy var rangeValuesStackView: UIStackView = {
         let stackView = UIStackView(

--- a/Tests/UnitTests/AccessibilityIdentifier/SliderAccessibilityIdentifierTests.swift
+++ b/Tests/UnitTests/AccessibilityIdentifier/SliderAccessibilityIdentifierTests.swift
@@ -22,4 +22,9 @@ final class SliderAccessibilityIdentifierTests: XCTestCase {
         // GIVEN / WHEN / THEN
         XCTAssertEqual(SliderAccessibilityIdentifier.slider, "spark-slider")
     }
+
+    func test_sliderContent_hasExpectedValue() {
+        // GIVEN / WHEN / THEN
+        XCTAssertEqual(SliderAccessibilityIdentifier.sliderContent, "spark-slider-content")
+    }
 }


### PR DESCRIPTION
Added a new accessibility identifier 'sliderContent' for the native slider inside SparkSlider and SparkUISlider components. This improves testability and accessibility by providing a distinct identifier for the slider content element. Updated unit tests to include coverage for the new identifier.